### PR TITLE
fix(merged): isolate provider failures to prevent cascading shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ go build \
   ./cmd/extractedprism
 ```
 
-Requires Go 1.25 or later.
+Requires Go 1.26 or later.
 
 ## Configuration
 
@@ -228,7 +228,7 @@ Contributions are welcome. To get started:
 
 Requirements:
 
-- Go 1.25 or later
+- Go 1.26 or later
 - golangci-lint v2 (the project uses strict linting with nearly all linters enabled)
 
 ## License

--- a/internal/discovery/merged/merged.go
+++ b/internal/discovery/merged/merged.go
@@ -71,7 +71,7 @@ func (mp *Provider) Run(ctx context.Context, updateCh chan<- []string) error {
 	defer errMu.Unlock()
 
 	if len(provErrs) > 0 && len(provErrs) == len(mp.providers) {
-		return provErrs[0]
+		return errors.Join(provErrs...)
 	}
 
 	return nil

--- a/internal/discovery/merged/merged_test.go
+++ b/internal/discovery/merged/merged_test.go
@@ -422,6 +422,8 @@ func TestRun_AllProvidersFailReturnsError(t *testing.T) {
 	select {
 	case err := <-errCh:
 		require.Error(t, err)
+		assert.True(t, errors.Is(err, err1), "combined error must contain err1")
+		assert.True(t, errors.Is(err, err2), "combined error must contain err2")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for error")
 	}


### PR DESCRIPTION
## Summary

- A single provider failure (e.g. Kubernetes API unavailable) no longer cancels all other providers via shared context
- Stale endpoints from failed providers are cleaned up by forwardUpdates on channel close, guaranteeing correct ordering
- Run returns an error only when ALL providers fail; errors are combined via `errors.Join`
- A monitor goroutine cancels the context when all providers complete (graceful or error), preventing deadlock
- All forwardUpdates goroutines are tracked in the WaitGroup so Run waits for full cleanup before returning

## Test plan

- [x] `TestRun_SingleProviderFailureDoesNotKillOthers` — healthy provider continues after failing one
- [x] `TestRun_FailedProviderEndpointsAreCleared` — stale endpoints removed after provider failure (stress-tested 50 runs)
- [x] `TestRun_AllProvidersFailReturnsError` — all errors preserved via `errors.Join`
- [x] `TestRun_GracefulExitPlusErrorDoesNotHang` — no deadlock with mixed exit types
- [x] `TestRun_AllGracefulExitReturnsNil` — graceful exit returns nil
- [x] `TestRun_ZeroProvidersReturnsError` — zero providers returns error
- [x] All tests pass with `-race -count=3`
- [x] `golangci-lint run` clean

Closes #11