### PR TITLE
fix(ci): replace pull_request_target with pull_request to prevent supply chain attacks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload Trivy filesystem results to GitHub Security
         if: (success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository
-        uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13 # v4
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-filesystem'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,7 +188,7 @@ jobs:
           docker buildx imagetools inspect ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign container images
         env:


### PR DESCRIPTION
## Summary

- Replace `pull_request_target` trigger with `pull_request` to eliminate supply chain attack vector where fork PRs could execute arbitrary code with write permissions to the base repository
- Pin all GitHub Actions to immutable commit SHAs (not mutable tags) in both `pr.yaml` and `release.yaml` workflows
- Move `security-events: write` and `pull-requests: write` from workflow-level to job-level permissions (principle of least privilege)
- Add fork guards on `build-and-push`, `merge-manifests`, and `notify` jobs so fork PRs still get lint/test/security but not container builds or PR notifications

## Test plan

- [ ] Verify PR workflow triggers correctly on new pull requests
- [ ] Verify fork PRs run lint, test, and security scan but skip build/push/notify jobs
- [ ] Verify same-repo PRs run the full pipeline including container build
- [ ] Verify REVISION build-arg in container image matches the PR head commit SHA

Closes #23