### PR TITLE
fix(health): add ReadTimeout, WriteTimeout, and IdleTimeout to HTTP server

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -12,7 +12,12 @@ import (
 	"go.uber.org/zap"
 )
 
-const readHeaderTimeout = 10 * time.Second
+const (
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 10 * time.Second
+	writeTimeout      = 10 * time.Second
+	idleTimeout       = 60 * time.Second
+)
 
 // Checker reports whether the system is healthy.
 type Checker interface {
@@ -44,9 +49,17 @@ func NewServer(bindAddress string, port int, checker Checker, logger *zap.Logger
 		Addr:              fmt.Sprintf("%s:%d", bindAddress, port),
 		Handler:           mux,
 		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
 
 	return srv
+}
+
+// HTTPServer returns the underlying http.Server for testing timeout configuration.
+func (s *Server) HTTPServer() *http.Server {
+	return s.httpServer
 }
 
 // ServeHTTP delegates to the internal mux so the server can be used with httptest.

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -101,6 +101,19 @@ func TestUnknownPathReturns404(t *testing.T) {
 	}
 }
 
+func TestNewServer_SetsAllTimeouts(t *testing.T) {
+	checker := &mockChecker{healthy: true}
+	srv := health.NewServer("127.0.0.1", 0, checker, newTestLogger())
+
+	httpSrv := srv.HTTPServer()
+	assert.NotZero(t, httpSrv.ReadHeaderTimeout, "ReadHeaderTimeout must be set")
+	assert.NotZero(t, httpSrv.ReadTimeout, "ReadTimeout must be set")
+	assert.NotZero(t, httpSrv.WriteTimeout, "WriteTimeout must be set")
+	assert.NotZero(t, httpSrv.IdleTimeout, "IdleTimeout must be set")
+	assert.Greater(t, httpSrv.ReadTimeout, httpSrv.ReadHeaderTimeout,
+		"ReadTimeout must be greater than ReadHeaderTimeout")
+}
+
 func TestShutdown(t *testing.T) {
 	checker := &mockChecker{healthy: true}
 	srv := health.NewServer("127.0.0.1", 0, checker, newTestLogger())


### PR DESCRIPTION
## Summary

- Add `ReadTimeout` (10s), `WriteTimeout` (10s), and `IdleTimeout` (60s) to the health HTTP server to prevent resource exhaustion attacks
- Reduce `ReadHeaderTimeout` from 10s to 5s so it is strictly less than `ReadTimeout`
- Add test verifying all timeout fields are configured

Previously only `ReadHeaderTimeout` was set, leaving the server vulnerable to slowloris variants (slow body after fast headers), slow-read attacks (blocked write goroutine), and connection exhaustion from immortal keep-alive connections.

## Test plan

- [x] `TestNewServer_SetsAllTimeouts` verifies all four timeout fields are non-zero and `ReadTimeout > ReadHeaderTimeout`
- [x] All existing health tests pass with race detector

Closes #24