### PR TITLE
fix(config): validate endpoint port as numeric value in range 1-65535

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All flags are bound to environment variables with the `EP_` prefix. For example,
 
 ### Validation rules
 
-- `--endpoints` must not be empty; each entry must be a valid `host:port` pair
+- `--endpoints` must not be empty; each entry must be a valid `host:port` pair where port is a number in the range 1-65535
 - `--bind-port` and `--health-port` must be in the range 1-65535 and must differ
 - `--health-timeout` must be less than `--health-interval`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,6 +84,11 @@ func validateEndpoints(endpoints []string) error {
 		host, port, err := net.SplitHostPort(endpoint)
 		if err != nil || host == "" || port == "" {
 			return errors.Wrap(ErrInvalidEndpoint, endpoint)
+		}
+
+		portNum, parseErr := strconv.Atoi(port)
+		if parseErr != nil || portNum < minPort || portNum > maxPort {
+			return errors.Wrapf(ErrInvalidEndpoint, "%s: port must be a number between 1 and 65535", endpoint)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Validate that endpoint ports are numeric values within range 1-65535 during startup config validation
- Provide a distinct error message when an endpoint has an invalid port vs invalid format
- Update README validation rules to document the port range requirement

## Test plan

- [x] `TestValidate_InvalidEndpointPort` covers non-numeric, zero, negative, float, and out-of-range ports
- [x] `TestValidate_EndpointPortBoundaryValid` covers boundary values (port 1 and 65535)
- [x] All existing config tests pass

Closes #20