### PR TITLE
fix(config): validate that health interval and timeout are positive durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ All flags are bound to environment variables with the `EP_` prefix. For example,
 - `--bind-address` must be a valid IP address or RFC 1123-compliant hostname
 - `--endpoints` must not be empty; each entry must be a valid `host:port` pair where port is a number in the range 1-65535
 - `--bind-port` and `--health-port` must be in the range 1-65535 and must differ
+- `--health-interval` and `--health-timeout` must be at least 1 second
 - `--health-timeout` must be less than `--health-interval`
 
 ## How it works

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,13 +24,16 @@ const (
 
 // Sentinel errors for configuration validation.
 var (
-	ErrNoEndpoints         = errors.New("no endpoints configured")
-	ErrInvalidEndpoint     = errors.New("invalid endpoint")
-	ErrInvalidPort         = errors.New("invalid port number")
-	ErrPortConflict        = errors.New("bind port and health port must differ")
-	ErrInvalidHealthTiming = errors.New("health timeout must be less than health interval")
-	ErrInvalidBindAddress  = errors.New("invalid bind address")
+	ErrNoEndpoints           = errors.New("no endpoints configured")
+	ErrInvalidEndpoint       = errors.New("invalid endpoint")
+	ErrInvalidPort           = errors.New("invalid port number")
+	ErrPortConflict          = errors.New("bind port and health port must differ")
+	ErrInvalidHealthTiming   = errors.New("health timeout must be less than health interval")
+	ErrInvalidBindAddress    = errors.New("invalid bind address")
+	ErrInvalidHealthDuration = errors.New("invalid health duration")
 )
+
+const minHealthDuration = 1 * time.Second
 
 // Config holds all configuration for the extractedprism proxy.
 type Config struct {
@@ -76,6 +79,14 @@ func (cfg *Config) Validate() error {
 	err = validatePorts(cfg.BindPort, cfg.HealthPort)
 	if err != nil {
 		return err
+	}
+
+	if cfg.HealthInterval < minHealthDuration {
+		return errors.Wrapf(ErrInvalidHealthDuration, "health interval %s: must be at least %s", cfg.HealthInterval, minHealthDuration)
+	}
+
+	if cfg.HealthTimeout < minHealthDuration {
+		return errors.Wrapf(ErrInvalidHealthDuration, "health timeout %s: must be at least %s", cfg.HealthTimeout, minHealthDuration)
 	}
 
 	if cfg.HealthTimeout >= cfg.HealthInterval {


### PR DESCRIPTION
## Summary

- Reject `--health-interval` and `--health-timeout` values below 1 second during config validation
- Prevents misconfiguration like nanosecond intervals, zero timeouts, or negative durations
- Add `ErrInvalidHealthDuration` sentinel error with descriptive wrapping

## Test plan

- [x] Invalid durations: zero, negative, sub-second for both interval and timeout
- [x] Boundary: minimum valid config (interval=2s, timeout=1s) passes
- [x] Existing `HealthTimeout >= HealthInterval` check still works
- [x] README validation rules updated
- [x] golangci-lint reports zero issues

Closes #27