### PR TITLE
fix(config): replace leftover NewDefault references with NewBaseConfig

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,7 +67,7 @@ func TestValidate_InvalidEndpoint(t *testing.T) {
 }
 
 func TestValidate_InvalidEndpoint_ErrorFormat(t *testing.T) {
-	cfg := config.NewDefault()
+	cfg := config.NewBaseConfig()
 	cfg.Endpoints = []string{"10.0.0.1"}
 
 	err := cfg.Validate()
@@ -78,7 +78,7 @@ func TestValidate_InvalidEndpoint_ErrorFormat(t *testing.T) {
 }
 
 func TestValidate_InvalidEndpointPort_ErrorFormat(t *testing.T) {
-	cfg := config.NewDefault()
+	cfg := config.NewBaseConfig()
 	cfg.Endpoints = []string{"10.0.0.1:abc"}
 
 	err := cfg.Validate()


### PR DESCRIPTION
## Summary

- Fix build breakage on master caused by two test functions from PR #43 that still referenced the removed `NewDefault()` constructor after PR #45 renamed it to `NewBaseConfig()`

## Test plan

- [x] `go test ./internal/config/` passes
- [x] `golangci-lint run ./internal/config/` reports zero issues