### PR TITLE
fix(ci): restore green CI under golangci-lint v2.12.2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Pre-install the Trivy binary with retries. The action's built-in
+      # setup downloads the binary from GitHub releases in a single attempt,
+      # which intermittently fails on a transient network error and breaks the
+      # whole job. Retrying the install removes that flake; the scan step below
+      # then reuses this binary via skip-setup-trivy.
+      - name: Install Trivy (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/v0.69.1/contrib/install.sh" \
+              | sh -s -- -b "${RUNNER_TEMP}/trivy-bin" v0.69.1 && break
+            echo "Trivy install attempt ${attempt} failed; retrying in 20s" >&2
+            sleep 20
+          done
+          test -x "${RUNNER_TEMP}/trivy-bin/trivy"
+          echo "${RUNNER_TEMP}/trivy-bin" >> "${GITHUB_PATH}"
+
       - name: Run Trivy vulnerability scanner (filesystem)
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
@@ -30,6 +46,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
+          skip-setup-trivy: true
 
       - name: Upload Trivy filesystem results to GitHub Security
         if: (success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository
@@ -54,7 +71,10 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          # Pin the linter version for reproducible CI. An unpinned "latest"
+          # silently upgrades golangci-lint, which can fail previously-green
+          # code when a new release adds or tightens linters.
+          version: v2.12.2
           args: --timeout=5m
 
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,10 @@ linters:
     - errchkjson
     - ireturn
     - gomoddirectives
+    # gomodguard is deprecated since golangci-lint v2.12.0 (replaced by
+    # gomodguard_v2). The project does not guard module imports, so there is
+    # nothing to carry over; disabling silences the deprecation warning.
+    - gomodguard
   settings:
     tagliatelle:
       case:
@@ -122,6 +126,11 @@ linters:
           - godox
           - revive
           - gochecknoglobals
+          # Test tables intentionally repeat short literals (case names like
+          # "empty string", log levels, endpoint fixtures). Extracting them to
+          # constants hurts readability without improving the production code
+          # goconst is meant to protect. Keep goconst on for non-test code.
+          - goconst
         path: _test\.go
       - linters:
           - godox

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -71,7 +71,7 @@ func TestHealthz_Alive_Returns200(t *testing.T) {
 	checker := newMockChecker(true, true)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -84,7 +84,7 @@ func TestHealthz_NotAlive_Returns503(t *testing.T) {
 	checker := newMockChecker(true, false)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -100,7 +100,7 @@ func TestHealthz_NotAlive_LogsWarning(t *testing.T) {
 	checker := newMockChecker(true, false)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, logger)
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -119,7 +119,7 @@ func TestHealthz_Alive_NoWarningLog(t *testing.T) {
 	checker := newMockChecker(true, true)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, logger)
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -136,7 +136,7 @@ func TestHealthz_NotAlive_LogsOnceNotOnEveryRequest(t *testing.T) {
 
 	// Send multiple requests while not alive.
 	for range 5 {
-		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 		rec := httptest.NewRecorder()
 
 		srv.ServeHTTP(rec, req)
@@ -154,7 +154,7 @@ func TestHealthz_LogsAgainAfterRecoveryAndReFailure(t *testing.T) {
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, logger)
 
 	// First failure — logs warning.
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -164,7 +164,7 @@ func TestHealthz_LogsAgainAfterRecoveryAndReFailure(t *testing.T) {
 	// Recovery.
 	checker.alive.Store(true)
 
-	req = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec = httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -174,7 +174,7 @@ func TestHealthz_LogsAgainAfterRecoveryAndReFailure(t *testing.T) {
 	// Second failure — should log again (new transition).
 	checker.alive.Store(false)
 
-	req = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec = httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -188,7 +188,7 @@ func TestHealthz_UsesSeparateLivenessChecker(t *testing.T) {
 	liveness := &mockLiveness{alive: false}
 	srv := health.NewServer("127.0.0.1", 0, checker, liveness, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -202,7 +202,7 @@ func TestHealthz_NotAlive_ContentType(t *testing.T) {
 	checker := newMockChecker(true, false)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -214,7 +214,7 @@ func TestReadyz_HealthyReturns200(t *testing.T) {
 	checker := newMockChecker(true, true)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -227,7 +227,7 @@ func TestReadyz_UnhealthyReturns503(t *testing.T) {
 	checker := newMockChecker(false, true)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -241,7 +241,7 @@ func TestReadyz_ErrorReturns503WithGenericMessage(t *testing.T) {
 		errors.New("dial tcp 10.0.0.1:6443: connection refused"))
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -262,7 +262,7 @@ func TestReadyz_ErrorLogsDetails(t *testing.T) {
 	checker := newMockCheckerWithErr(false, true, internalErr)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, logger)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -284,7 +284,7 @@ func TestHealthz_ContentType(t *testing.T) {
 	checker := newMockChecker(true, true)
 	srv := health.NewServer("127.0.0.1", 0, checker, checker, newTestLogger())
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
 	srv.ServeHTTP(rec, req)
@@ -306,7 +306,7 @@ func TestReadyz_ContentType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := health.NewServer("127.0.0.1", 0, tt.checker, tt.checker, newTestLogger())
 
-			req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/readyz", nil)
 			rec := httptest.NewRecorder()
 
 			srv.ServeHTTP(rec, req)
@@ -326,7 +326,7 @@ func TestMethodNotAllowed(t *testing.T) {
 	for _, path := range paths {
 		for _, method := range methods {
 			t.Run(path+"/"+method, func(t *testing.T) {
-				req := httptest.NewRequest(method, path, nil)
+				req := httptest.NewRequestWithContext(t.Context(), method, path, nil)
 				rec := httptest.NewRecorder()
 
 				srv.ServeHTTP(rec, req)
@@ -347,7 +347,7 @@ func TestOptions_Returns204WithAllow(t *testing.T) {
 
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodOptions, path, nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, path, nil)
 			rec := httptest.NewRecorder()
 
 			srv.ServeHTTP(rec, req)
@@ -398,7 +398,7 @@ func TestUnknownPathReturns404(t *testing.T) {
 	paths := []string{"/", "/health", "/ready", "/metrics", "/foo"}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
 			rec := httptest.NewRecorder()
 
 			srv.ServeHTTP(rec, req)


### PR DESCRIPTION
## What

Restores green CI. Two recent breakages surfaced on an unrelated PR, neither caused by a code change:

1. The lint job pulled golangci-lint `latest`, which advanced to v2.12.2 and flagged previously-green code: `noctx` on `httptest.NewRequest`, and `goconst` now scanning test files at the project's `min-occurrences: 2`.
2. The Security Scan intermittently failed while downloading the Trivy binary from GitHub releases.

## Changes

- Switch the health server tests to `httptest.NewRequestWithContext` (`noctx`).
- Exclude `goconst` from `_test.go`: at `min-occurrences: 2` it flags table-test case names ("empty string", log levels) and fixtures, where extracting constants hurts readability without protecting production code. `goconst` stays enabled for non-test code.
- Drop the deprecated `gomodguard` linter (replaced by `gomodguard_v2` since v2.12.0); the project does not guard module imports, so nothing carries over.
- Pin golangci-lint to `v2.12.2` instead of `latest`, so a future release cannot silently break unrelated PRs.
- Pre-install the Trivy binary in a retry loop and reuse it via `skip-setup-trivy`, so a transient download error no longer fails the job.

## Verification

- `golangci-lint run --timeout=5m` -> 0 issues.
- `go test --race ./...` -> all packages pass.
- Test-only and CI-only; no production code behavior changes.