### PR TITLE
ci: adopt the renamed linters for golangci-lint 2.13

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,7 +62,7 @@ jobs:
           # Pin the linter version for reproducible CI. An unpinned "latest"
           # silently upgrades golangci-lint, which can fail previously-green
           # code when a new release adds or tightens linters.
-          version: v2.12.2
+          version: v2.13.2
           args: --timeout=5m
 
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   disable:
     - depguard
     - exhaustruct
+    - exhaustruct_v5
     - gochecknoinits
     - wsl
     - lll
@@ -15,6 +16,7 @@ linters:
     # gomodguard_v2). The project does not guard module imports, so there is
     # nothing to carry over; disabling silences the deprecation warning.
     - gomodguard
+    - gomodguard_v2
   settings:
     tagliatelle:
       case:


### PR DESCRIPTION
golangci-lint 2.13 renames `exhaustruct`, `gomodguard` and `wsl` to their `_v5` / `_v2` variants. Under `linters.default: all` both generations are active at once, so a `disable` entry naming only one of a pair leaves the other one running. That is why the 2.13 bump shows up with findings the config already meant to silence.

Both names are listed now, and the pin moves to 2.13.2.

That version matters for two reasons beyond the rename. It ships `honnef.co/go/tools` v0.8.1, which fixes the nilness panic that made every 2.13 bump fail on the sentry package (dominikh/go-tools#1725, closed on 20 August). And it is built with go1.27.0, so the pending Go 1.27 bump stops tripping `the Go language version used to build golangci-lint is lower than the targeted Go version`.

Verified by running 2.13.2 against this repo: no findings.